### PR TITLE
Expose revision kwarg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /mix_eval/eval_scripts
 build_dynamic_benchmark_version_control.sh
 __pycache__/
+
+# MixEval stuff
+results/

--- a/mix_eval/evaluate.py
+++ b/mix_eval/evaluate.py
@@ -50,6 +50,12 @@ def parse_args():
         help="Path to local model, only work with model_name='local_chat'."
         )
     parser.add_argument(
+        "--model_revision",
+        type=str,
+        default=None,
+        help="The model revision to use. If not specified, the latest revision will be used."
+        )
+    parser.add_argument(
         "--benchmark", 
         type=str, 
         required=True, 

--- a/mix_eval/models/base.py
+++ b/mix_eval/models/base.py
@@ -48,6 +48,7 @@ class ModelBase:
             
         model = AutoModelForCausalLM.from_pretrained(
             self.model_name,
+            revision=self.revision,
             torch_dtype=self.model_dtype,
             trust_remote_code=self.trust_remote_code,
             **kwargs
@@ -57,6 +58,7 @@ class ModelBase:
     def build_tokenizer(self):
         tokenizer = AutoTokenizer.from_pretrained(
             self.model_name,
+            revision=self.revision,
             model_max_length=self.model_max_len,
             padding_side=self.padding_side,
             use_fast=self.use_fast_tokenizer,
@@ -179,6 +181,7 @@ class ChatModel(ModelBase):
     def __init__(self, args):
         super().__init__(args)
         self.model_name = None
+        self.revision = None
         self.attn_implementation = None
         
         self.SYSTEM_MESSAGE = {"role": "system", "content": "You are a helpful assistant."} # set to None if no system message
@@ -311,6 +314,7 @@ class BaseModel(ModelBase):
     def __init__(self, args):
         super().__init__(args)
         self.model_name = None
+        self.revision = None
         self.attn_implementation = None # If use default, set to None
         
         self.closeended_max_new_tokens = self.closeended_max_new_tokens_basemodel

--- a/mix_eval/models/local_chat.py
+++ b/mix_eval/models/local_chat.py
@@ -9,6 +9,7 @@ class LocalChatModel(ChatModel):
     def __init__(self, args):
         super().__init__(args)
         self.model_name = args.model_path # updates path to local model
+        self.revision = args.model_revision
         self.attn_implementation = "flash_attention_2" # If use default, set to None
         self.model_dtype = torch.bfloat16
         self.trust_remote_code = True
@@ -28,6 +29,7 @@ class LocalChatModel(ChatModel):
     def build_tokenizer(self):
         tokenizer = AutoTokenizer.from_pretrained(
             self.model_name,
+            revision=self.revision,
             model_max_length=self.model_max_len,
             trust_remote_code=self.trust_remote_code)
         return tokenizer


### PR DESCRIPTION
Exposes the `revision` kwarg for local models. This is needed to evaluate checkpoints stored on e.g. separate branches of a model repo.

Tested with:

```bash
# should fail to find revision
MODEL_PARSER_API=$(echo $OPENAI_API_KEY) python -m mix_eval.evaluate     --data_path hf://zeitgeist-ai/mixeval     --model_path HuggingFaceH4/zephyr-7b-beta --model_re
vision foo     --output_dir results/agi-5     --model_name local_chat     --benchmark mixeval_hard     --version 2024-06-01     --batch_size 20     --api_parallel_num 20

# works!
MODEL_PARSER_API=$(echo $OPENAI_API_KEY) python -m mix_eval.evaluate     --data_path hf://zeitgeist-ai/mixeval     --model_path HuggingFaceH4/zephyr-7b-beta --model_re
vision main     --output_dir results/agi-5     --model_name local_chat     --benchmark mixeval_hard     --version 2024-06-01     --batch_size 20     --api_parallel_num 20
```